### PR TITLE
split_punct: shift periods

### DIFF
--- a/lib/engtagger.rb
+++ b/lib/engtagger.rb
@@ -683,6 +683,7 @@ class EngTagger
     # Handle all other punctuation
     text = text.gsub(/--+/o, " - ") # Convert and separate dashes
     text = text.gsub(/,(?!\d)/o, " , ") # Shift commas off everything but numbers
+    text = text.gsub(/\.(?!\d)/o, " . ") # Shift periods off everything but numbers
     text = text.gsub(/:/o, " :") # Shift semicolons off
     text = text.gsub(/(\.\.\.+)/o){" " + $1 + " "} # Shift ellipses off
     text = text.gsub(/([\(\[\{\}\]\)])/o){" " + $1 + " "} # Shift off brackets


### PR DESCRIPTION
Fixes the following problem:
tagger = EngTagger.new
tagger.get_readable("they will soon raise rates.")
 => "they/PRP will/MD soon/RB raise/VB rates/NNS ./PP"
tagger.get_readable("they will soon raise rates. ok")
 => "they/PRP will/MD soon/RB raise/VB rates./NN ok/NN"

Signed-off-by: Dimid Duchovny <dimidd@gmail.com>